### PR TITLE
Remove unnecessary rule suffix

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -2,17 +2,17 @@
 
 use Danger\Config;
 use Danger\Context;
-use Danger\Rule\CheckPhpCsFixerRule;
-use Danger\Rule\CheckPhpStanRule;
-use Danger\Rule\CommitRegexRule;
-use Danger\Rule\MaxCommitRule;
+use Danger\Rule\CheckPhpCsFixer;
+use Danger\Rule\CheckPhpStan;
+use Danger\Rule\CommitRegex;
+use Danger\Rule\MaxCommit;
 use Danger\Struct\File;
 
 return (new Config())
-    ->useRule(new CommitRegexRule('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m'))
-    ->useRule(new MaxCommitRule(1))
-    ->useRule(new CheckPhpCsFixerRule())
-    ->useRule(new CheckPhpStanRule())
+    ->useRule(new CommitRegex('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m'))
+    ->useRule(new MaxCommit(1))
+    ->useRule(new CheckPhpCsFixer())
+    ->useRule(new CheckPhpStan())
     ->useRule(function (Context $context) {
         $prFiles = $context
             ->platform

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Use the [prebuilt Docker image](https://github.com/users/shyim/packages/containe
 <?php declare(strict_types=1);
 
 use Danger\Config;
-use Danger\Rule\DisallowRepeatedCommitsRule;
+use Danger\Rule\DisallowRepeatedCommits;
 
 return (new Config())
-    ->useRule(new DisallowRepeatedCommitsRule) // Disallows multiple commits with the same message
+    ->useRule(new DisallowRepeatedCommits) // Disallows multiple commits with the same message
 ;
 ```
 
@@ -58,10 +58,10 @@ return (new Config())
 <?php declare(strict_types=1);
 
 use Danger\Config;
-use Danger\Rule\MaxCommitRule;
+use Danger\Rule\MaxCommit;
 
 return (new Config())
-    ->useRule(new MaxCommitRule(1))
+    ->useRule(new MaxCommit(1))
 ;
 
 

--- a/docs/builtin-rules.md
+++ b/docs/builtin-rules.md
@@ -1,10 +1,10 @@
 # Builtin rules
 
-## \Danger\Rule\CheckPhpCsFixerRule
+## \Danger\Rule\CheckPhpCsFixer
 
 Runs PHP-CS-Fixer in background and adds a failure if the command is failed
 
-## \Danger\Rule\CommitRegexRule
+## \Danger\Rule\CommitRegex
 
 Checks that the Commit message matches the regex
 
@@ -13,7 +13,7 @@ Checks that the Commit message matches the regex
 - regex (string)
 - (optional) message (string)
 
-## \Danger\Rule\DisallowRepeatedCommitsRule
+## \Danger\Rule\DisallowRepeatedCommits
 
 Checks that the commit messages are unique inside the pull request
 
@@ -21,7 +21,7 @@ Checks that the commit messages are unique inside the pull request
 
 - (optional) message (string)
 
-## \Danger\Rule\MaxCommitRule
+## \Danger\Rule\MaxCommit
 
 Checks the commit amount in the pull request
 
@@ -30,7 +30,7 @@ Checks the commit amount in the pull request
 - maxAmount (int) default: 1
 - (optional) message (string)
 
-## \Danger\Rule\ConditionRule
+## \Danger\Rule\Condition
 
 Allows running multiple rules when a condition is met
 
@@ -48,21 +48,21 @@ Allows running multiple rules when a condition is met
 use Danger\Context;
 use Danger\Config;
 use Danger\Platform\Github\Github;
-use Danger\Rule\CommitRegexRule;
-use Danger\Rule\ConditionRule;
-use Danger\Rule\MaxCommitRule;
+use Danger\Rule\CommitRegex;
+use Danger\Rule\Condition;
+use Danger\Rule\MaxCommit;
 
 /**
  * We check the commit amount and commit message only when the target platform is Github
  */
 return (new Config())
-    ->useRule(new ConditionRule(
+    ->useRule(new Condition(
             function (Context $context) {
                 return $context->platform instanceof Github;
             },
             [
-                new MaxCommitRule(1),
-                new CommitRegexRule('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m')
+                new MaxCommit(1),
+                new CommitRegex('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m')
             ]
         ));
 ```

--- a/src/Application.php
+++ b/src/Application.php
@@ -10,6 +10,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class Application extends SymfonyApplication
 {
+    public const PACKAGE_NAME = 'shyim/danger-php';
+    public const RULE_DEPRECATION_MESSAGE = 'This rule is deprecated. Use %s instead.';
+
     private ContainerInterface $container;
 
     public function __construct()
@@ -17,9 +20,9 @@ class Application extends SymfonyApplication
         parent::__construct('Danger', '__VERSION__');
         $this->container = Container::getContainer();
 
-        foreach (array_keys($this->container->findTaggedServiceIds('console.command')) as $command) {
+        foreach (array_keys($this->container->findTaggedServiceIds('console.command')) as $taggedService) {
             /** @var Command $command */
-            $command = $this->container->get($command);
+            $command = $this->container->get($taggedService);
 
             $this->add($command);
         }

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -32,10 +32,10 @@ class InitCommand extends Command
         file_put_contents($path, '<?php declare(strict_types=1);
 
 use Danger\Config;
-use Danger\Rule\DisallowRepeatedCommitsRule;
+use Danger\Rule\DisallowRepeatedCommits;
 
 return (new Config())
-    ->useRule(new DisallowRepeatedCommitsRule) // Disallows multiple commits with the same message
+    ->useRule(new DisallowRepeatedCommits) // Disallows multiple commits with the same message
 ;
 ');
         $io->success(sprintf('Created %s', $path));

--- a/src/Rule/CheckPhpCsFixer.php
+++ b/src/Rule/CheckPhpCsFixer.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Rule;
+
+use Danger\Context;
+
+/**
+ * Runs PhpCsFixer and adds a failure to danger if failing
+ */
+class CheckPhpCsFixer
+{
+    public function __construct(
+        private string $command = 'php vendor/bin/php-cs-fixer fix --format=json',
+        private string $executionFailed = 'PHP-CS-Fixer did not run',
+        private string $foundErrors = 'Found some Code-Style issues. Please run <code>./vendor/bin/php-cs-fixer fix</code> on your branch'
+    ) {
+    }
+
+    public function __invoke(Context $context): void
+    {
+        exec($this->command, $cmdOutput, $resultCode);
+
+        // @codeCoverageIgnoreStart
+        if (!isset($cmdOutput[0])) {
+            $context->failure($this->executionFailed);
+        }
+        // @codeCoverageIgnoreEnd
+
+        if (count(json_decode($cmdOutput[0], true)['files'])) {
+            $context->failure($this->foundErrors);
+        }
+    }
+}

--- a/src/Rule/CheckPhpCsFixerRule.php
+++ b/src/Rule/CheckPhpCsFixerRule.php
@@ -3,32 +3,23 @@ declare(strict_types=1);
 
 namespace Danger\Rule;
 
-use Danger\Context;
+use Danger\Application;
 
 /**
- * Runs PhpCsFixer and adds a failure to danger if failing
+ * @codeCoverageIgnore
+ *
+ * @deprecated use \Danger\Rule\CheckPhpCsFixer instead
  */
-class CheckPhpCsFixerRule
+class CheckPhpCsFixerRule extends CheckPhpCsFixer
 {
     public function __construct(
-        private string $command = 'php vendor/bin/php-cs-fixer fix --format=json',
-        private string $executionFailed = 'PHP-CS-Fixer did not run',
-        private string $foundErrors = 'Found some Code-Style issues. Please run <code>./vendor/bin/php-cs-fixer fix</code> on your branch'
+        string $command = 'php vendor/bin/php-cs-fixer fix --format=json',
+        string $executionFailed = 'PHP-CS-Fixer did not run',
+        string $foundErrors = 'Found some Code-Style issues. Please run <code>./vendor/bin/php-cs-fixer fix</code> on your branch'
     ) {
-    }
+        $deprecationMessage = sprintf(Application::RULE_DEPRECATION_MESSAGE, CheckPhpCsFixer::class);
+        trigger_deprecation(Application::PACKAGE_NAME, '0.1.5', $deprecationMessage);
 
-    public function __invoke(Context $context): void
-    {
-        exec($this->command, $cmdOutput, $resultCode);
-
-        // @codeCoverageIgnoreStart
-        if (!isset($cmdOutput[0])) {
-            $context->failure($this->executionFailed);
-        }
-        // @codeCoverageIgnoreEnd
-
-        if (count(json_decode($cmdOutput[0], true)['files'])) {
-            $context->failure($this->foundErrors);
-        }
+        parent::__construct($command, $executionFailed, $foundErrors);
     }
 }

--- a/src/Rule/CheckPhpStan.php
+++ b/src/Rule/CheckPhpStan.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Rule;
+
+use Danger\Context;
+
+class CheckPhpStan
+{
+    public function __construct(
+        private string $command = './vendor/bin/phpstan --error-format=json --no-progress',
+        private string $message = 'PHPStan check failed. Run locally <code>./vendor/bin/phpstan --error-format=json --no-progress</code> to see the errors.'
+    ) {
+    }
+
+    public function __invoke(Context $context): void
+    {
+        exec($this->command, $cmdOutput, $resultCode);
+
+        if ($resultCode !== 0) {
+            $context->failure($this->message);
+        }
+    }
+}

--- a/src/Rule/CheckPhpStanRule.php
+++ b/src/Rule/CheckPhpStanRule.php
@@ -3,22 +3,22 @@ declare(strict_types=1);
 
 namespace Danger\Rule;
 
-use Danger\Context;
+use Danger\Application;
 
-class CheckPhpStanRule
+/**
+ * @codeCoverageIgnore
+ *
+ * @deprecated use \Danger\Rule\CheckPhpStan instead
+ */
+class CheckPhpStanRule extends CheckPhpStan
 {
     public function __construct(
-        private string $command = './vendor/bin/phpstan --error-format=json --no-progress',
-        private string $message = 'PHPStan check failed. Run locally <code>./vendor/bin/phpstan --error-format=json --no-progress</code> to see the errors.'
+        string $command = './vendor/bin/phpstan --error-format=json --no-progress',
+        string $message = 'PHPStan check failed. Run locally <code>./vendor/bin/phpstan --error-format=json --no-progress</code> to see the errors.'
     ) {
-    }
+        $deprecationMessage = sprintf(Application::RULE_DEPRECATION_MESSAGE, CheckPhpStan::class);
+        trigger_deprecation(Application::PACKAGE_NAME, '0.1.5', $deprecationMessage);
 
-    public function __invoke(Context $context): void
-    {
-        exec($this->command, $cmdOutput, $resultCode);
-
-        if ($resultCode !== 0) {
-            $context->failure($this->message);
-        }
+        parent::__construct($command, $message);
     }
 }

--- a/src/Rule/CommitRegex.php
+++ b/src/Rule/CommitRegex.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Rule;
+
+use Danger\Context;
+
+class CommitRegex
+{
+    public function __construct(private string $regex, private string $message = 'The commit message "###MESSAGE###" does not match the regex ###REGEX###')
+    {
+    }
+
+    public function __invoke(Context $context): void
+    {
+        foreach ($context->platform->pullRequest->getCommits() as $commit) {
+            if (!preg_match($this->regex, $commit->message)) {
+                $context->failure(str_replace(['###MESSAGE###', '###REGEX###'], [$commit->message, $this->regex], $this->message));
+            }
+        }
+    }
+}

--- a/src/Rule/CommitRegexRule.php
+++ b/src/Rule/CommitRegexRule.php
@@ -3,20 +3,20 @@ declare(strict_types=1);
 
 namespace Danger\Rule;
 
-use Danger\Context;
+use Danger\Application;
 
-class CommitRegexRule
+/**
+ * @codeCoverageIgnore
+ *
+ * @deprecated use \Danger\Rule\CommitRegex instead
+ */
+class CommitRegexRule extends CommitRegex
 {
-    public function __construct(private string $regex, private string $message = 'The commit message "###MESSAGE###" does not match the regex ###REGEX###')
+    public function __construct(string $regex, string $message = 'The commit message "###MESSAGE###" does not match the regex ###REGEX###')
     {
-    }
+        $deprecationMessage = sprintf(Application::RULE_DEPRECATION_MESSAGE, CommitRegex::class);
+        trigger_deprecation(Application::PACKAGE_NAME, '0.1.5', $deprecationMessage);
 
-    public function __invoke(Context $context): void
-    {
-        foreach ($context->platform->pullRequest->getCommits() as $commit) {
-            if (!preg_match($this->regex, $commit->message)) {
-                $context->failure(str_replace(['###MESSAGE###', '###REGEX###'], [$commit->message, $this->regex], $this->message));
-            }
-        }
+        parent::__construct($regex, $message);
     }
 }

--- a/src/Rule/Condition.php
+++ b/src/Rule/Condition.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Rule;
+
+use Danger\Context;
+
+class Condition
+{
+    /**
+     * @var callable
+     */
+    private $condition;
+
+    /**
+     * @param callable[] $rules
+     */
+    public function __construct(callable $condition, private array $rules)
+    {
+        $this->condition = $condition;
+    }
+
+    public function __invoke(Context $context): void
+    {
+        $condition = $this->condition;
+
+        if (!$condition($context)) {
+            return;
+        }
+
+        foreach ($this->rules as $rule) {
+            $rule($context);
+        }
+    }
+}

--- a/src/Rule/ConditionRule.php
+++ b/src/Rule/ConditionRule.php
@@ -3,33 +3,23 @@ declare(strict_types=1);
 
 namespace Danger\Rule;
 
-use Danger\Context;
+use Danger\Application;
 
-class ConditionRule
+/**
+ * @codeCoverageIgnore
+ *
+ * @deprecated use \Danger\Rule\Condition instead
+ */
+class ConditionRule extends Condition
 {
     /**
-     * @var callable
+     * {@inheritDoc}
      */
-    private $condition;
-
-    /**
-     * @param callable[] $rules
-     */
-    public function __construct(callable $condition, private array $rules)
+    public function __construct(callable $condition, array $rules)
     {
-        $this->condition = $condition;
-    }
+        $deprecationMessage = sprintf(Application::RULE_DEPRECATION_MESSAGE, Condition::class);
+        trigger_deprecation(Application::PACKAGE_NAME, '0.1.5', $deprecationMessage);
 
-    public function __invoke(Context $context): void
-    {
-        $condition = $this->condition;
-
-        if (!$condition($context)) {
-            return;
-        }
-
-        foreach ($this->rules as $rule) {
-            $rule($context);
-        }
+        parent::__construct($condition, $rules);
     }
 }

--- a/src/Rule/DisallowRepeatedCommits.php
+++ b/src/Rule/DisallowRepeatedCommits.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Rule;
+
+use Danger\Context;
+
+class DisallowRepeatedCommits
+{
+    public function __construct(private string $message = 'You should not use the same commit message multiple times')
+    {
+    }
+
+    public function __invoke(Context $context): void
+    {
+        $messages = $context->platform->pullRequest->getCommits()->getMessages();
+
+        if (count($messages) !== count(array_unique($messages))) {
+            $context->failure($this->message);
+        }
+    }
+}

--- a/src/Rule/DisallowRepeatedCommitsRule.php
+++ b/src/Rule/DisallowRepeatedCommitsRule.php
@@ -3,20 +3,20 @@ declare(strict_types=1);
 
 namespace Danger\Rule;
 
-use Danger\Context;
+use Danger\Application;
 
-class DisallowRepeatedCommitsRule
+/**
+ * @codeCoverageIgnore
+ *
+ * @deprecated use \Danger\Rule\DisallowRepeatedCommits instead
+ */
+class DisallowRepeatedCommitsRule extends DisallowRepeatedCommits
 {
-    public function __construct(private string $message = 'You should not use the same commit message multiple times')
+    public function __construct(string $message = 'You should not use the same commit message multiple times')
     {
-    }
+        $deprecationMessage = sprintf(Application::RULE_DEPRECATION_MESSAGE, DisallowRepeatedCommits::class);
+        trigger_deprecation(Application::PACKAGE_NAME, '0.1.5', $deprecationMessage);
 
-    public function __invoke(Context $context): void
-    {
-        $messages = $context->platform->pullRequest->getCommits()->getMessages();
-
-        if (count($messages) !== count(array_unique($messages))) {
-            $context->failure($this->message);
-        }
+        parent::__construct($message);
     }
 }

--- a/src/Rule/MaxCommit.php
+++ b/src/Rule/MaxCommit.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Rule;
+
+use Danger\Context;
+
+class MaxCommit
+{
+    public function __construct(private int $maxCommits = 1, private string $message = 'Please squash your commits to ###AMOUNT### only')
+    {
+    }
+
+    public function __invoke(Context $context): void
+    {
+        if (count($context->platform->pullRequest->getCommits()) > $this->maxCommits) {
+            $message = $this->maxCommits . ' commits';
+            if ($this->maxCommits === 1) {
+                $message = 'one commit';
+            }
+
+            $context->failure(str_replace(['###AMOUNT###'], [$message], $this->message));
+        }
+    }
+}

--- a/src/Rule/MaxCommitRule.php
+++ b/src/Rule/MaxCommitRule.php
@@ -3,23 +3,20 @@ declare(strict_types=1);
 
 namespace Danger\Rule;
 
-use Danger\Context;
+use Danger\Application;
 
-class MaxCommitRule
+/**
+ * @codeCoverageIgnore
+ *
+ * @deprecated use \Danger\Rule\MaxCommit instead
+ */
+class MaxCommitRule extends MaxCommit
 {
-    public function __construct(private int $maxCommits = 1, private string $message = 'Please squash your commits to ###AMOUNT### only')
+    public function __construct(int $maxCommits = 1, string $message = 'Please squash your commits to ###AMOUNT### only')
     {
-    }
+        $deprecationMessage = sprintf(Application::RULE_DEPRECATION_MESSAGE, MaxCommit::class);
+        trigger_deprecation(Application::PACKAGE_NAME, '0.1.5', $deprecationMessage);
 
-    public function __invoke(Context $context): void
-    {
-        if (count($context->platform->pullRequest->getCommits()) > $this->maxCommits) {
-            $message = $this->maxCommits . ' commits';
-            if ($this->maxCommits === 1) {
-                $message = 'one commit';
-            }
-
-            $context->failure(str_replace(['###AMOUNT###'], [$message], $this->message));
-        }
+        parent::__construct($maxCommits, $message);
     }
 }

--- a/tests/Rule/CheckPhpCsFixerTest.php
+++ b/tests/Rule/CheckPhpCsFixerTest.php
@@ -5,35 +5,35 @@ namespace Danger\Tests\Rule;
 
 use Danger\Context;
 use Danger\Platform\Github\Github;
-use Danger\Rule\CheckPhpStanRule;
+use Danger\Rule\CheckPhpCsFixer;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-class CheckPhpStanRuleTest extends TestCase
+class CheckPhpCsFixerTest extends TestCase
 {
-    public function testValid(): void
+    public function testRuleRunsWithoutIssues(): void
     {
         $github = $this->createMock(Github::class);
         $context = new Context($github);
 
-        $rule = new CheckPhpStanRule();
+        $rule = new CheckPhpCsFixer();
         $rule($context);
 
         static::assertFalse($context->hasFailures());
     }
 
-    public function testInvalid(): void
+    public function testRuleFailures(): void
     {
         $github = $this->createMock(Github::class);
         $context = new Context($github);
 
         $path = dirname(__DIR__, 2) . '/src/Test.php';
 
-        file_put_contents($path, '<?php str_contains(new ArrayObject());');
+        file_put_contents($path, '<?php var_dump(\'foo\');;;');
 
-        $rule = new CheckPhpStanRule();
+        $rule = new CheckPhpCsFixer();
         $rule($context);
 
         static::assertTrue($context->hasFailures());

--- a/tests/Rule/CheckPhpStanTest.php
+++ b/tests/Rule/CheckPhpStanTest.php
@@ -5,35 +5,35 @@ namespace Danger\Tests\Rule;
 
 use Danger\Context;
 use Danger\Platform\Github\Github;
-use Danger\Rule\CheckPhpCsFixerRule;
+use Danger\Rule\CheckPhpStan;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-class CheckPhpCsFixerRuleTest extends TestCase
+class CheckPhpStanTest extends TestCase
 {
-    public function testRuleRunsWithoutIssues(): void
+    public function testValid(): void
     {
         $github = $this->createMock(Github::class);
         $context = new Context($github);
 
-        $rule = new CheckPhpCsFixerRule();
+        $rule = new CheckPhpStan();
         $rule($context);
 
         static::assertFalse($context->hasFailures());
     }
 
-    public function testRuleFailures(): void
+    public function testInvalid(): void
     {
         $github = $this->createMock(Github::class);
         $context = new Context($github);
 
         $path = dirname(__DIR__, 2) . '/src/Test.php';
 
-        file_put_contents($path, '<?php var_dump(\'foo\');;;');
+        file_put_contents($path, '<?php str_contains(new ArrayObject());');
 
-        $rule = new CheckPhpCsFixerRule();
+        $rule = new CheckPhpStan();
         $rule($context);
 
         static::assertTrue($context->hasFailures());

--- a/tests/Rule/CommitRegexTest.php
+++ b/tests/Rule/CommitRegexTest.php
@@ -5,7 +5,7 @@ namespace Danger\Tests\Rule;
 
 use Danger\Context;
 use Danger\Platform\Github\Github;
-use Danger\Rule\MaxCommitRule;
+use Danger\Rule\CommitRegex;
 use Danger\Struct\Commit;
 use Danger\Struct\CommitCollection;
 use Danger\Struct\Github\PullRequest;
@@ -14,18 +14,21 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-class MaxCommitRuleTest extends TestCase
+class CommitRegexTest extends TestCase
 {
     public function testRuleMatches(): void
     {
+        $commit = new Commit();
+        $commit->message = 'Test';
+
         $github = $this->createMock(Github::class);
         $pr = $this->createMock(PullRequest::class);
-        $pr->method('getCommits')->willReturn(new CommitCollection([new Commit(), new Commit()]));
+        $pr->method('getCommits')->willReturn(new CommitCollection([$commit]));
         $github->pullRequest = $pr;
 
         $context = new Context($github);
 
-        $rule = new MaxCommitRule();
+        $rule = new CommitRegex('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m');
         $rule($context);
 
         static::assertTrue($context->hasFailures());
@@ -33,14 +36,17 @@ class MaxCommitRuleTest extends TestCase
 
     public function testRuleNotMatches(): void
     {
+        $commit = new Commit();
+        $commit->message = 'feat: Test';
+
         $github = $this->createMock(Github::class);
         $pr = $this->createMock(PullRequest::class);
-        $pr->method('getCommits')->willReturn(new CommitCollection([new Commit()]));
+        $pr->method('getCommits')->willReturn(new CommitCollection([$commit]));
         $github->pullRequest = $pr;
 
         $context = new Context($github);
+        $rule = new CommitRegex('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m');
 
-        $rule = new MaxCommitRule();
         $rule($context);
 
         static::assertFalse($context->hasFailures());

--- a/tests/Rule/ConditionTest.php
+++ b/tests/Rule/ConditionTest.php
@@ -6,13 +6,13 @@ namespace Danger\Tests\Rule;
 use Danger\Context;
 use Danger\Platform\Github\Github;
 use Danger\Platform\Gitlab\Gitlab;
-use Danger\Rule\ConditionRule;
+use Danger\Rule\Condition;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
  */
-class ConditionRuleTest extends TestCase
+class ConditionTest extends TestCase
 {
     public function testConditionMet(): void
     {
@@ -20,7 +20,7 @@ class ConditionRuleTest extends TestCase
         $context = new Context($github);
         $innerRuleExecuted = false;
 
-        $rule = new ConditionRule(
+        $rule = new Condition(
             function (Context $context) {
                 return $context->platform instanceof Github;
             },
@@ -42,7 +42,7 @@ class ConditionRuleTest extends TestCase
         $context = new Context($github);
         $innerRuleExecuted = false;
 
-        $rule = new ConditionRule(
+        $rule = new Condition(
             function (Context $context) {
                 return $context->platform instanceof Gitlab;
             },

--- a/tests/Rule/DisallowRepeatedCommitsTest.php
+++ b/tests/Rule/DisallowRepeatedCommitsTest.php
@@ -5,7 +5,7 @@ namespace Danger\Tests\Rule;
 
 use Danger\Context;
 use Danger\Platform\Github\Github;
-use Danger\Rule\CommitRegexRule;
+use Danger\Rule\DisallowRepeatedCommits;
 use Danger\Struct\Commit;
 use Danger\Struct\CommitCollection;
 use Danger\Struct\Github\PullRequest;
@@ -14,21 +14,24 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-class CommitRegexRuleTest extends TestCase
+class DisallowRepeatedCommitsTest extends TestCase
 {
     public function testRuleMatches(): void
     {
         $commit = new Commit();
         $commit->message = 'Test';
 
+        $secondCommit = new Commit();
+        $secondCommit->message = 'Test';
+
         $github = $this->createMock(Github::class);
         $pr = $this->createMock(PullRequest::class);
-        $pr->method('getCommits')->willReturn(new CommitCollection([$commit]));
+        $pr->method('getCommits')->willReturn(new CommitCollection([$commit, $secondCommit]));
         $github->pullRequest = $pr;
 
         $context = new Context($github);
 
-        $rule = new CommitRegexRule('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m');
+        $rule = new DisallowRepeatedCommits();
         $rule($context);
 
         static::assertTrue($context->hasFailures());
@@ -37,16 +40,19 @@ class CommitRegexRuleTest extends TestCase
     public function testRuleNotMatches(): void
     {
         $commit = new Commit();
-        $commit->message = 'feat: Test';
+        $commit->message = 'Test';
+
+        $secondCommit = new Commit();
+        $secondCommit->message = 'Test2';
 
         $github = $this->createMock(Github::class);
         $pr = $this->createMock(PullRequest::class);
-        $pr->method('getCommits')->willReturn(new CommitCollection([$commit]));
+        $pr->method('getCommits')->willReturn(new CommitCollection([$commit, $secondCommit]));
         $github->pullRequest = $pr;
 
         $context = new Context($github);
-        $rule = new CommitRegexRule('/^(feat|fix|docs|perf|refactor|compat|chore)(\(.+\))?\:\s(.{3,})/m');
 
+        $rule = new DisallowRepeatedCommits();
         $rule($context);
 
         static::assertFalse($context->hasFailures());

--- a/tests/Rule/MaxCommitTest.php
+++ b/tests/Rule/MaxCommitTest.php
@@ -5,7 +5,7 @@ namespace Danger\Tests\Rule;
 
 use Danger\Context;
 use Danger\Platform\Github\Github;
-use Danger\Rule\DisallowRepeatedCommitsRule;
+use Danger\Rule\MaxCommit;
 use Danger\Struct\Commit;
 use Danger\Struct\CommitCollection;
 use Danger\Struct\Github\PullRequest;
@@ -14,24 +14,18 @@ use PHPUnit\Framework\TestCase;
 /**
  * @internal
  */
-class DisallowRepeatedCommitsRuleTest extends TestCase
+class MaxCommitTest extends TestCase
 {
     public function testRuleMatches(): void
     {
-        $commit = new Commit();
-        $commit->message = 'Test';
-
-        $secondCommit = new Commit();
-        $secondCommit->message = 'Test';
-
         $github = $this->createMock(Github::class);
         $pr = $this->createMock(PullRequest::class);
-        $pr->method('getCommits')->willReturn(new CommitCollection([$commit, $secondCommit]));
+        $pr->method('getCommits')->willReturn(new CommitCollection([new Commit(), new Commit()]));
         $github->pullRequest = $pr;
 
         $context = new Context($github);
 
-        $rule = new DisallowRepeatedCommitsRule();
+        $rule = new MaxCommit();
         $rule($context);
 
         static::assertTrue($context->hasFailures());
@@ -39,20 +33,14 @@ class DisallowRepeatedCommitsRuleTest extends TestCase
 
     public function testRuleNotMatches(): void
     {
-        $commit = new Commit();
-        $commit->message = 'Test';
-
-        $secondCommit = new Commit();
-        $secondCommit->message = 'Test2';
-
         $github = $this->createMock(Github::class);
         $pr = $this->createMock(PullRequest::class);
-        $pr->method('getCommits')->willReturn(new CommitCollection([$commit, $secondCommit]));
+        $pr->method('getCommits')->willReturn(new CommitCollection([new Commit()]));
         $github->pullRequest = $pr;
 
         $context = new Context($github);
 
-        $rule = new DisallowRepeatedCommitsRule();
+        $rule = new MaxCommit();
         $rule($context);
 
         static::assertFalse($context->hasFailures());


### PR DESCRIPTION
Hi!
First of all, great project!

While setting up the configuration in a private project, I noticed the "Rule" suffix on all bundled rules.
I don't think this is necessary since all of the classes live in the `\Danger\Rule` namespace already.
