### PR TITLE
Added possibility to decide on which level a thread is started

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,17 +80,40 @@ return (new Config())
 **Currently only supported on GitLab**
 
 This option allows using a thread instead of a comment in the Pull Request.
+You can declare for which level of report you want to use a thread.
 
+Use thread if reports has at least one failure:
 ```php
 <?php declare(strict_types=1);
 
 use Danger\Config;
 
 return (new Config())
-    ->useThreadOnFails()
+    ->useThreadOn(Config::REPORT_LEVEL_FAILURE)
 ;
 ```
 
+Use thread if reports has at least one warning:
+```php
+<?php declare(strict_types=1);
+
+use Danger\Config;
+
+return (new Config())
+    ->useThreadOn(Config::REPORT_LEVEL_WARNING)
+;
+```
+
+Use thread if reports has at least one notice:
+```php
+<?php declare(strict_types=1);
+
+use Danger\Config;
+
+return (new Config())
+    ->useThreadOn(Config::REPORT_LEVEL_NOTICE)
+;
+```
 ## useGithubCommentProxy
 
 **Currently only supported on Github**

--- a/src/Command/CiCommand.php
+++ b/src/Command/CiCommand.php
@@ -9,7 +9,9 @@ use Danger\Platform\PlatformDetector;
 use Danger\Renderer\HTMLRenderer;
 use Danger\Runner;
 use InvalidArgumentException;
+
 use function is_string;
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Command/GithubCommand.php
+++ b/src/Command/GithubCommand.php
@@ -8,7 +8,9 @@ use Danger\Context;
 use Danger\Platform\Github\Github;
 use Danger\Runner;
 use InvalidArgumentException;
+
 use function is_string;
+
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Command/GitlabCommand.php
+++ b/src/Command/GitlabCommand.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 namespace Danger\Command;
 
 use function assert;
+
 use Danger\ConfigLoader;
 use Danger\Context;
 use Danger\Platform\Gitlab\Gitlab;
 use Danger\Runner;
 use InvalidArgumentException;
+
 use function is_string;
+
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Command/InitCommand.php
+++ b/src/Command/InitCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Command;
 
 use const LOCK_EX;
+
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Config.php
+++ b/src/Config.php
@@ -8,6 +8,11 @@ class Config
     public const UPDATE_COMMENT_MODE_REPLACE = 'replace';
     public const UPDATE_COMMENT_MODE_UPDATE = 'update';
 
+    public const REPORT_LEVEL_FAILURE = 32;
+    public const REPORT_LEVEL_WARNING = 16;
+    public const REPORT_LEVEL_NOTICE = 8;
+    public const REPORT_LEVEL_NONE = 0;
+
     /**
      * @var callable[]
      */
@@ -22,7 +27,7 @@ class Config
 
     private ?string $githubCommentProxyUrl = null;
 
-    private bool $useThread = false;
+    private int $useThreadOn = 0;
 
     public function useRule(callable $closure): static
     {
@@ -78,15 +83,54 @@ class Config
         return $this->githubCommentProxyUrl;
     }
 
+    /**
+     * @deprecated will be removed - use useThreadOn instead
+     */
     public function useThreadOnFails(bool $enable = true): static
     {
-        $this->useThread = $enable;
+        $this->useThreadOn = $enable ? self::REPORT_LEVEL_FAILURE : self::REPORT_LEVEL_NONE;
+
+        return $this;
+    }
+
+    public function useThreadOn(int $useTreadOn): static
+    {
+        $this->useThreadOn = $useTreadOn;
 
         return $this;
     }
 
     public function isThreadEnabled(): bool
     {
-        return $this->useThread;
+        return $this->useThreadOn > 0;
+    }
+
+    public function getUseThreadOn(): int
+    {
+        return $this->useThreadOn;
+    }
+
+    /**
+     * Get the highest report level of the given context
+     */
+    public function getReportLevel(Context $context): int
+    {
+        if (!$context->hasReports()) {
+            return self::REPORT_LEVEL_NONE;
+        }
+
+        if ($context->hasFailures()) {
+            return self::REPORT_LEVEL_FAILURE;
+        }
+
+        if ($context->hasWarnings()) {
+            return self::REPORT_LEVEL_WARNING;
+        }
+
+        if ($context->hasNotices()) {
+            return self::REPORT_LEVEL_NOTICE;
+        }
+
+        return self::REPORT_LEVEL_NONE;
     }
 }

--- a/src/ConfigLoader.php
+++ b/src/ConfigLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger;
 
 use function assert;
+
 use Danger\Exception\InvalidConfigurationException;
 
 class ConfigLoader

--- a/src/Context.php
+++ b/src/Context.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger;
 
 use function count;
+
 use Danger\Platform\AbstractPlatform;
 
 class Context

--- a/src/DependencyInjection/Container.php
+++ b/src/DependencyInjection/Container.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\DependencyInjection;
 
 use function dirname;
+
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/src/Platform/Github/Github.php
+++ b/src/Platform/Github/Github.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Platform\Github;
 
 use function count;
+
 use Danger\Config;
 use Danger\Platform\AbstractPlatform;
 use Danger\Struct\Github\PullRequest as GithubPullRequest;

--- a/src/Platform/Github/GithubCommenter.php
+++ b/src/Platform/Github/GithubCommenter.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 namespace Danger\Platform\Github;
 
 use function count;
+
 use Danger\Config;
 use Danger\Renderer\HTMLRenderer;
 use Github\Client;
 use Github\ResultPager;
+
 use const JSON_THROW_ON_ERROR;
+
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use UnexpectedValueException;
 

--- a/src/Platform/Gitlab/Gitlab.php
+++ b/src/Platform/Gitlab/Gitlab.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Platform\Gitlab;
 
 use function count;
+
 use Danger\Config;
 use Danger\Platform\AbstractPlatform;
 use Danger\Struct\Gitlab\PullRequest;

--- a/src/Platform/Gitlab/GitlabCommenter.php
+++ b/src/Platform/Gitlab/GitlabCommenter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Platform\Gitlab;
 
 use function count;
+
 use Danger\Config;
 use Danger\Renderer\HTMLRenderer;
 use Gitlab\Client;

--- a/src/Renderer/HTMLRenderer.php
+++ b/src/Renderer/HTMLRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Renderer;
 
 use Danger\Context;
+
 use function str_replace;
 
 class HTMLRenderer

--- a/src/Rule/CheckPhpCsFixer.php
+++ b/src/Rule/CheckPhpCsFixer.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 namespace Danger\Rule;
 
 use function count;
+
 use Danger\Context;
 use Danger\Struct\File;
+
 use const JSON_THROW_ON_ERROR;
+
 use Symfony\Component\Filesystem\Filesystem;
 
 /**

--- a/src/Rule/DisallowRepeatedCommits.php
+++ b/src/Rule/DisallowRepeatedCommits.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Rule;
 
 use function count;
+
 use Danger\Context;
 
 class DisallowRepeatedCommits

--- a/src/Rule/MaxCommit.php
+++ b/src/Rule/MaxCommit.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Rule;
 
 use function count;
+
 use Danger\Context;
 
 class MaxCommit

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Danger;
 
-use function count;
-
 class Runner
 {
     public function run(Config $config, Context $context): void
@@ -20,11 +18,8 @@ class Runner
             $afterHook($context);
         }
 
-        /**
-         * When useThreadOnFails is enabled but no failures enabled deactivate it
-         */
-        if ($config->isThreadEnabled() && count($context->getFailures()) === 0) {
-            $config->useThreadOnFails(false);
+        if ($config->getReportLevel($context) <= $config->getUseThreadOn()) {
+            $config->useThreadOn(Config::REPORT_LEVEL_NONE);
         }
     }
 }

--- a/src/Struct/Collection.php
+++ b/src/Struct/Collection.php
@@ -5,8 +5,11 @@ namespace Danger\Struct;
 
 use function array_key_exists;
 use function array_slice;
+
 use Closure;
+
 use function count;
+
 use Countable;
 use Generator;
 use IteratorAggregate;

--- a/tests/Command/CiCommandTest.php
+++ b/tests/Command/CiCommandTest.php
@@ -9,7 +9,9 @@ use Danger\Platform\Github\Github;
 use Danger\Platform\PlatformDetector;
 use Danger\Renderer\HTMLRenderer;
 use Danger\Runner;
+
 use function dirname;
+
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;

--- a/tests/Command/GithubCommandTest.php
+++ b/tests/Command/GithubCommandTest.php
@@ -7,7 +7,9 @@ use Danger\Command\GithubCommand;
 use Danger\ConfigLoader;
 use Danger\Platform\Github\Github;
 use Danger\Runner;
+
 use function dirname;
+
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;

--- a/tests/Command/GitlabCommandTest.php
+++ b/tests/Command/GitlabCommandTest.php
@@ -7,7 +7,9 @@ use Danger\Command\GitlabCommand;
 use Danger\ConfigLoader;
 use Danger\Platform\Gitlab\Gitlab;
 use Danger\Runner;
+
 use function dirname;
+
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;

--- a/tests/ConfigLoaderTest.php
+++ b/tests/ConfigLoaderTest.php
@@ -5,7 +5,9 @@ namespace Danger\Tests;
 
 use Danger\ConfigLoader;
 use Danger\Exception\InvalidConfigurationException;
+
 use function dirname;
+
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -19,8 +19,21 @@ class ConfigTest extends TestCase
         static::assertCount(1, $config->getRules());
 
         static::assertFalse($config->isThreadEnabled());
-        $config->useThreadOnFails();
+        $config->useThreadOnFails(); /** @phpstan-ignore-line */
         static::assertTrue($config->isThreadEnabled());
+
+        $config->useThreadOnFails(false); /** @phpstan-ignore-line */
+        $config->useThreadOn(Config::REPORT_LEVEL_WARNING);
+        static::assertEquals(Config::REPORT_LEVEL_WARNING, $config->getUseThreadOn());
+
+        $config->useThreadOn(Config::REPORT_LEVEL_WARNING);
+        static::assertEquals(Config::REPORT_LEVEL_WARNING, $config->getUseThreadOn());
+
+        $config->useThreadOn(Config::REPORT_LEVEL_NOTICE);
+        static::assertEquals(Config::REPORT_LEVEL_NOTICE, $config->getUseThreadOn());
+
+        $config->useThreadOn(Config::REPORT_LEVEL_NONE);
+        static::assertEquals(Config::REPORT_LEVEL_NONE, $config->getUseThreadOn());
 
         static::assertNull($config->getGithubCommentProxy());
         $config->useGithubCommentProxy('http://localhost');

--- a/tests/Platform/Github/GithubTest.php
+++ b/tests/Platform/Github/GithubTest.php
@@ -10,7 +10,9 @@ use Danger\Struct\Comment;
 use Danger\Struct\Commit;
 use Danger\Struct\File;
 use Github\Client;
+
 use const JSON_THROW_ON_ERROR;
+
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\HttpClient\MockHttpClient;

--- a/tests/Platform/Gitlab/GitlabCommenterTest.php
+++ b/tests/Platform/Gitlab/GitlabCommenterTest.php
@@ -82,7 +82,7 @@ class GitlabCommenterTest extends TestCase
         ]);
 
         $client = Client::createWithHttpClient(new Psr18Client($mockHttpClient));
-        $config = (new Config())->useThreadOnFails();
+        $config = (new Config())->useThreadOn(Config::REPORT_LEVEL_FAILURE);
 
         $commenter = new GitlabCommenter($client);
         $url = $commenter->postThread('test', 1, 'test', $config, 'https://gitlab.com');
@@ -98,7 +98,7 @@ class GitlabCommenterTest extends TestCase
         ]);
 
         $client = Client::createWithHttpClient(new Psr18Client($mockHttpClient));
-        $config = (new Config())->useThreadOnFails();
+        $config = (new Config())->useThreadOn(Config::REPORT_LEVEL_FAILURE);
 
         $commenter = new GitlabCommenter($client);
         $url = $commenter->postThread('test', 1, 'test', $config, 'https://gitlab.com');
@@ -115,7 +115,7 @@ class GitlabCommenterTest extends TestCase
         ]);
 
         $client = Client::createWithHttpClient(new Psr18Client($mockHttpClient));
-        $config = (new Config())->useThreadOnFails()->useCommentMode(Config::UPDATE_COMMENT_MODE_REPLACE);
+        $config = (new Config())->useThreadOn(Config::REPORT_LEVEL_FAILURE)->useCommentMode(Config::UPDATE_COMMENT_MODE_REPLACE);
 
         $commenter = new GitlabCommenter($client);
         $url = $commenter->postThread('test', 1, 'test', $config, 'https://gitlab.com');

--- a/tests/Platform/Gitlab/GitlabTest.php
+++ b/tests/Platform/Gitlab/GitlabTest.php
@@ -11,7 +11,9 @@ use Danger\Struct\Commit;
 use Danger\Struct\File;
 use Gitlab\Client;
 use InvalidArgumentException;
+
 use const JSON_THROW_ON_ERROR;
+
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Psr18Client;
@@ -126,7 +128,7 @@ class GitlabTest extends TestCase
         $gitlab->load('test', '1');
 
         static::assertSame('https://gitlab.com', $gitlab->post('Test', new Config()));
-        static::assertSame('https://gitlab.com', $gitlab->post('Test', (new Config())->useThreadOnFails()));
+        static::assertSame('https://gitlab.com', $gitlab->post('Test', (new Config())->useThreadOn(Config::REPORT_LEVEL_FAILURE)));
     }
 
     public function testRemove(): void
@@ -144,7 +146,7 @@ class GitlabTest extends TestCase
         $gitlab = new Gitlab($client, $commenter);
         $gitlab->load('test', '1');
         $gitlab->removePost(new Config());
-        $gitlab->removePost((new Config())->useThreadOnFails());
+        $gitlab->removePost((new Config())->useThreadOn(Config::REPORT_LEVEL_FAILURE));
     }
 
     public function testLabels(): void

--- a/tests/Rule/CheckPhpCsFixerTest.php
+++ b/tests/Rule/CheckPhpCsFixerTest.php
@@ -9,7 +9,9 @@ use Danger\Rule\CheckPhpCsFixer;
 use Danger\Struct\FileCollection;
 use Danger\Struct\Github\PullRequest;
 use Danger\Tests\Struct\TestFile;
+
 use const PHP_VERSION_ID;
+
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/Rule/CheckPhpStanTest.php
+++ b/tests/Rule/CheckPhpStanTest.php
@@ -6,8 +6,11 @@ namespace Danger\Tests\Rule;
 use Danger\Context;
 use Danger\Platform\Github\Github;
 use Danger\Rule\CheckPhpStan;
+
 use function dirname;
+
 use PHPUnit\Framework\TestCase;
+
 use function unlink;
 
 /**

--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -23,7 +23,7 @@ class RunnerTest extends TestCase
 
         $config = new Config();
         $config->useRule(function () use (&$ruleExecuted, &$afterExecuted): void {
-            static::assertFalse($afterExecuted);
+            static::assertFalse($afterExecuted); /** @phpstan-ignore-line */
             $ruleExecuted = true;
         });
 
@@ -32,7 +32,7 @@ class RunnerTest extends TestCase
             $afterExecuted = true;
         });
 
-        $config->useThreadOnFails();
+        $config->useThreadOn(Config::REPORT_LEVEL_FAILURE);
         $runner->run($config, new Context($this->createMock(Github::class)));
 
         static::assertTrue($ruleExecuted);

--- a/tests/configs/all.php
+++ b/tests/configs/all.php
@@ -9,4 +9,4 @@ return
             $context->warning('A Warning');
             $context->notice('A Notice');
         })
-    ;
+;

--- a/tests/configs/warning.php
+++ b/tests/configs/warning.php
@@ -7,4 +7,4 @@ return
         ->useRule(function (Danger\Context $context): void {
             $context->warning('Test');
         })
-    ;
+;


### PR DESCRIPTION
With `useThreadOn` it can be decided on which minimum report level a thread is started in gitlab instead of a note.

This can be used to start a thread even on warnings so it will be less likely that the warning will be missed.