### PR TITLE
feat: add local run support, fixes #632

### DIFF
--- a/src/Command/LocalCommand.php
+++ b/src/Command/LocalCommand.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Command;
+
+use Danger\ConfigLoader;
+use Danger\Context;
+use Danger\Platform\Local\LocalPlatform;
+use Danger\Runner;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+#[AsCommand(name: 'local')]
+class LocalCommand extends AbstractPlatformCommand
+{
+    public function __construct(private ConfigLoader $configLoader, private Runner $runner, private LocalPlatform $localPlatform)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Run local danger on local git')
+            ->addOption('root', null, InputOption::VALUE_OPTIONAL, 'Git Path', (string) getcwd())
+            ->addOption('head-branch', null, InputOption::VALUE_OPTIONAL, 'Head Branch')
+            ->addOption('config', 'c', InputOption::VALUE_OPTIONAL, 'Path to Config file')
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $configPath = $input->getOption('config');
+        $headBranch = $input->getOption('head-branch');
+        $root = $input->getOption('root');
+
+        if ($configPath !== null && !\is_string($configPath)) {
+            throw new \InvalidArgumentException('Invalid config option given');
+        }
+
+        if ($root === null || !\is_string($root)) {
+            throw new \InvalidArgumentException('Invalid root option given');
+        }
+
+        if ($headBranch === null) {
+            $process = new Process(['git', 'symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
+            $process->mustRun();
+            $headBranch = trim(basename($process->getOutput()));
+        }
+
+        $process = new Process(['git', 'rev-parse', '--abbrev-ref', 'HEAD']);
+        $process->mustRun();
+        $localBranch = trim(basename($process->getOutput()));
+
+        $config = $this->configLoader->loadByPath($configPath);
+
+        $this->localPlatform->load($root, $localBranch . '|' . $headBranch);
+
+        $context = new Context($this->localPlatform);
+
+        $this->runner->run($config, $context);
+
+        return $this->handleReport($input, $output, $context);
+    }
+}

--- a/src/Command/LocalCommand.php
+++ b/src/Command/LocalCommand.php
@@ -45,12 +45,12 @@ class LocalCommand extends AbstractPlatformCommand
         }
 
         if ($headBranch === null) {
-            $process = new Process(['git', 'symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
+            $process = new Process(['git', 'symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], $root);
             $process->mustRun();
             $headBranch = trim(basename($process->getOutput()));
         }
 
-        $process = new Process(['git', 'rev-parse', '--abbrev-ref', 'HEAD']);
+        $process = new Process(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], $root);
         $process->mustRun();
         $localBranch = trim(basename($process->getOutput()));
 

--- a/src/Command/LocalCommand.php
+++ b/src/Command/LocalCommand.php
@@ -40,7 +40,7 @@ class LocalCommand extends AbstractPlatformCommand
             throw new \InvalidArgumentException('Invalid config option given');
         }
 
-        if ($root === null || !\is_string($root)) {
+        if (!\is_string($root)) {
             throw new \InvalidArgumentException('Invalid root option given');
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -115,10 +115,6 @@ class Config
      */
     public function getReportLevel(Context $context): int
     {
-        if (!$context->hasReports()) {
-            return self::REPORT_LEVEL_NONE;
-        }
-
         if ($context->hasFailures()) {
             return self::REPORT_LEVEL_FAILURE;
         }

--- a/src/Platform/Local/LocalPlatform.php
+++ b/src/Platform/Local/LocalPlatform.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Platform\Local;
+
+use Danger\Config;
+use Danger\Platform\AbstractPlatform;
+use Danger\Struct\Local\LocalPullRequest;
+
+class LocalPlatform extends AbstractPlatform
+{
+    private bool $didCommented = false;
+
+    public function load(string $projectIdentifier, string $id): void
+    {
+        [$localBranch, $targetBranch] = explode('|', $id);
+
+        $this->pullRequest = new LocalPullRequest($projectIdentifier, $localBranch, $targetBranch);
+    }
+
+    public function post(string $body, Config $config): string
+    {
+        $this->didCommented = true;
+
+        return '';
+    }
+
+    public function removePost(Config $config): void
+    {
+    }
+
+    public function hasDangerMessage(): bool
+    {
+        return $this->didCommented;
+    }
+}

--- a/src/Struct/Collection.php
+++ b/src/Struct/Collection.php
@@ -3,12 +3,10 @@ declare(strict_types=1);
 
 namespace Danger\Struct;
 
-use IteratorAggregate;
-
 /**
  * @template T
  *
- * @implements IteratorAggregate<T>
+ * @implements \IteratorAggregate<array-key, T>
  */
 abstract class Collection implements \IteratorAggregate, \Countable
 {

--- a/src/Struct/Local/LocalFile.php
+++ b/src/Struct/Local/LocalFile.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Struct\Local;
+
+use Danger\Struct\File;
+
+class LocalFile extends File
+{
+    public function __construct(private string $file)
+    {
+    }
+
+    public function getContent(): string
+    {
+        return (string) file_get_contents($this->file);
+    }
+}

--- a/src/Struct/Local/LocalPullRequest.php
+++ b/src/Struct/Local/LocalPullRequest.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Struct\Local;
+
+use Danger\Struct\CommentCollection;
+use Danger\Struct\Commit;
+use Danger\Struct\CommitCollection;
+use Danger\Struct\File;
+use Danger\Struct\FileCollection;
+use Danger\Struct\PullRequest;
+use Symfony\Component\Process\Process;
+
+class LocalPullRequest extends PullRequest
+{
+    /**
+     * @var CommitCollection<Commit>|null
+     */
+    private ?CommitCollection $commits = null;
+
+    /**
+     * @var FileCollection<File>|null
+     */
+    private ?FileCollection $files = null;
+
+    public function __construct(private string $repo, private string $local, private string $target)
+    {
+        $this->id = $this->local;
+        $this->body = '';
+
+        $commits = $this->getCommits();
+
+        if ($commits->count() > 0) {
+            $firstCommit = $commits->first();
+            \assert($firstCommit !== null);
+            $this->title = $firstCommit->message;
+            $this->createdAt = $firstCommit->createdAt;
+            $this->updatedAt = $firstCommit->createdAt;
+        } else {
+            $this->title = 'empty';
+            $this->createdAt = new \DateTime();
+            $this->updatedAt = new \DateTime();
+        }
+    }
+
+    public function getCommits(): CommitCollection
+    {
+        if ($this->commits !== null) {
+            return $this->commits;
+        }
+
+        $process = new Process([
+            'git',
+            'log',
+            '--pretty=format:\'{%n  "commit": "%H",%n  "abbreviated_commit": "%h",%n  "tree": "%T",%n  "abbreviated_tree": "%t",%n  "parent": "%P",%n  "abbreviated_parent": "%p",%n  "refs": "%D",%n  "encoding": "%e",%n  "subject": "%s",%n  "sanitized_subject_line": "%f",%n  "body": "%b",%n  "commit_notes": "%N",%n  "verification_flag": "%G?",%n  "signer": "%GS",%n  "signer_key": "%GK",%n  "author": {%n    "name": "%aN",%n    "email": "%aE",%n    "date": "%aD"%n  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE",%n    "date": "%cD"%n  }%n},\'',
+            $this->target . '..' . $this->local,
+        ], $this->repo);
+
+        $process->mustRun();
+
+        $commits = new CommitCollection();
+
+        /** @var array{commit: string, author: array{name: string, email: string, date: string}, subject: string}[] $gitOutput */
+        $gitOutput = json_decode('[' . mb_substr(trim($process->getOutput(), '\''), 0, -1) . ']', true);
+
+        foreach ($gitOutput as $commit) {
+            $commitObj = new Commit();
+            $commitObj->sha = $commit['commit'];
+            $commitObj->author = $commit['author']['name'];
+            $commitObj->authorEmail = $commit['author']['email'];
+            $commitObj->message = $commit['subject'];
+            $commitObj->createdAt = new \DateTime($commit['author']['date']);
+
+            $commits->add($commitObj);
+        }
+
+        return $this->commits = $commits;
+    }
+
+    public function getFiles(): FileCollection
+    {
+        if ($this->files !== null) {
+            return $this->files;
+        }
+
+        $process = new Process([
+            'git',
+            'diff',
+            $this->target . '..' . $this->local,
+            '--name-status',
+        ], $this->repo);
+
+        $process->mustRun();
+
+        $files = new FileCollection();
+
+        foreach (explode(\PHP_EOL, $process->getOutput()) as $line) {
+            if ($line === '') {
+                continue;
+            }
+
+            $status = $line[0];
+            $file = trim(mb_substr($line, 1));
+
+            $element = new LocalFile($this->repo . '/' . $file);
+            $element->name = $file;
+            $element->additions = 0;
+            $element->changes = 0;
+            $element->deletions = 0;
+
+            if ($status === 'A') {
+                $element->status = File::STATUS_ADDED;
+            } elseif ($status === 'M') {
+                $element->status = File::STATUS_MODIFIED;
+            } else {
+                $element->status = File::STATUS_REMOVED;
+            }
+
+            $files->add($element);
+        }
+
+        return $this->files = $files;
+    }
+
+    public function getComments(): CommentCollection
+    {
+        return new CommentCollection();
+    }
+}

--- a/src/Struct/Local/LocalPullRequest.php
+++ b/src/Struct/Local/LocalPullRequest.php
@@ -51,7 +51,7 @@ class LocalPullRequest extends PullRequest
         $process = new Process([
             'git',
             'log',
-            '--pretty=format:\'{%n  "commit": "%H",%n  "abbreviated_commit": "%h",%n  "tree": "%T",%n  "abbreviated_tree": "%t",%n  "parent": "%P",%n  "abbreviated_parent": "%p",%n  "refs": "%D",%n  "encoding": "%e",%n  "subject": "%s",%n  "sanitized_subject_line": "%f",%n  "body": "%b",%n  "commit_notes": "%N",%n  "verification_flag": "%G?",%n  "signer": "%GS",%n  "signer_key": "%GK",%n  "author": {%n    "name": "%aN",%n    "email": "%aE",%n    "date": "%aD"%n  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE",%n    "date": "%cD"%n  }%n},\'',
+            '--pretty=format:{%n  "commit": "%H",%n  "abbreviated_commit": "%h",%n  "tree": "%T",%n  "abbreviated_tree": "%t",%n  "parent": "%P",%n  "abbreviated_parent": "%p",%n  "refs": "%D",%n  "encoding": "%e",%n  "subject": "%s",%n  "sanitized_subject_line": "%f",%n  "body": "%b",%n  "commit_notes": "%N",%n  "verification_flag": "%G?",%n  "signer": "%GS",%n  "signer_key": "%GK",%n  "author": {%n    "name": "%aN",%n    "email": "%aE",%n    "date": "%aD"%n  },%n  "commiter": {%n    "name": "%cN",%n    "email": "%cE",%n    "date": "%cD"%n  }%n},',
             $this->target . '..' . $this->local,
         ], $this->repo);
 
@@ -60,7 +60,7 @@ class LocalPullRequest extends PullRequest
         $commits = new CommitCollection();
 
         /** @var array{commit: string, author: array{name: string, email: string, date: string}, subject: string}[] $gitOutput */
-        $gitOutput = json_decode('[' . mb_substr(trim($process->getOutput(), '\''), 0, -1) . ']', true);
+        $gitOutput = json_decode('[' . mb_substr($process->getOutput(), 0, -1) . ']', true);
 
         foreach ($gitOutput as $commit) {
             $commitObj = new Commit();
@@ -109,13 +109,11 @@ class LocalPullRequest extends PullRequest
 
             if ($status === 'A') {
                 $element->status = File::STATUS_ADDED;
-            } elseif ($status === 'M') {
-                $element->status = File::STATUS_MODIFIED;
             } else {
                 $element->status = File::STATUS_REMOVED;
             }
 
-            $files->add($element);
+            $files->set($element->name, $element);
         }
 
         return $this->files = $files;

--- a/src/Struct/PullRequest.php
+++ b/src/Struct/PullRequest.php
@@ -13,9 +13,9 @@ abstract class PullRequest
 
     public string $body;
 
-    public \DateTime $createdAt;
+    public \DateTimeInterface $createdAt;
 
-    public \DateTime $updatedAt;
+    public \DateTimeInterface $updatedAt;
 
     /**
      * @var string[]
@@ -25,22 +25,22 @@ abstract class PullRequest
     /**
      * @var string[]
      */
-    public array $assignees;
+    public array $assignees = [];
 
     /**
      * @var string[]
      */
-    public array $reviewers;
+    public array $reviewers = [];
 
     /**
      * @var array<string, array{'id': string, 'committed_date': string, 'message': 'string', 'author_name': string, 'author_email': string}|string>
      */
-    public array $rawCommits;
+    public array $rawCommits = [];
 
     /**
      * @var array{'changes': array{'new_path': string, 'diff'?: string, 'new_file': bool, 'deleted_file': bool}[]}
      */
-    public array $rawFiles;
+    public array $rawFiles = ['changes' => []];
 
     /**
      * @return CommitCollection<Commit>

--- a/tests/Command/LocalCommandTest.php
+++ b/tests/Command/LocalCommandTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Tests\Command;
+
+use Danger\Command\LocalCommand;
+use Danger\ConfigLoader;
+use Danger\Platform\Local\LocalPlatform;
+use Danger\Runner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\NullOutput;
+
+/**
+ * @covers \Danger\Command\LocalCommand
+ *
+ * @internal
+ */
+class LocalCommandTest extends TestCase
+{
+    public function testInvalidConfig(): void
+    {
+        $cmd = new LocalCommand(new ConfigLoader(), new Runner(), $this->createMock(LocalPlatform::class));
+
+        static::expectException(\InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid config option given');
+
+        $input = new ArgvInput(['danger']);
+        $input->bind($cmd->getDefinition());
+        $input->setOption('config', []);
+
+        $cmd->execute($input, new NullOutput());
+    }
+
+    public function testInvalidRoot(): void
+    {
+        $cmd = new LocalCommand(new ConfigLoader(), new Runner(), $this->createMock(LocalPlatform::class));
+
+        static::expectException(\InvalidArgumentException::class);
+        static::expectExceptionMessage('Invalid root option given');
+
+        $input = new ArgvInput(['danger']);
+        $input->bind($cmd->getDefinition());
+        $input->setOption('root', []);
+
+        $cmd->execute($input, new NullOutput());
+    }
+
+    public function testCommand(): void
+    {
+        $cmd = new LocalCommand(new ConfigLoader(), new Runner(), $this->createMock(LocalPlatform::class));
+
+        $input = new ArgvInput(['danger', '--config=' . \dirname(__DIR__) . '/configs/empty.php']);
+        $input->bind($cmd->getDefinition());
+
+        $output = new BufferedOutput();
+        $returnCode = $cmd->execute($input, $output);
+
+        static::assertStringContainsString('PR looks good', $output->fetch());
+        static::assertSame(0, $returnCode);
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 namespace Danger\Tests;
 
 use Danger\Config;
+use Danger\Context;
+use Danger\Platform\AbstractPlatform;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ *
+ * @covers \Danger\Config
  */
 class ConfigTest extends TestCase
 {
@@ -45,5 +49,24 @@ class ConfigTest extends TestCase
 
         $config->after(static function (): void {});
         static::assertCount(1, $config->getAfterHooks());
+    }
+
+    public function testGetReportLevelNotice(): void
+    {
+        $config = new Config();
+
+        $context = new Context($this->createMock(AbstractPlatform::class));
+        $context->notice('test');
+
+        static::assertSame(Config::REPORT_LEVEL_NOTICE, $config->getReportLevel($context));
+    }
+
+    public function testGetReportLevelNone(): void
+    {
+        $config = new Config();
+
+        $context = new Context($this->createMock(AbstractPlatform::class));
+
+        static::assertSame(Config::REPORT_LEVEL_NONE, $config->getReportLevel($context));
     }
 }

--- a/tests/Platform/Local/LocalPlatformTest.php
+++ b/tests/Platform/Local/LocalPlatformTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Tests\Platform\Local;
+
+use Danger\Config;
+use Danger\Platform\Local\LocalPlatform;
+use Danger\Struct\Local\LocalPullRequest;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * @covers \Danger\Platform\Local\LocalPlatform
+ *
+ * @internal
+ */
+class LocalPlatformTest extends TestCase
+{
+    public function testPlatform(): void
+    {
+        $platform = new LocalPlatform();
+
+        static::assertFalse($platform->hasDangerMessage());
+        $platform->removePost(new Config());
+        static::assertFalse($platform->hasDangerMessage());
+
+        $platform->post('test', new Config());
+        static::assertTrue($platform->hasDangerMessage());
+    }
+
+    public function testLoad(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('local', true);
+
+        mkdir($tmpDir);
+        file_put_contents($tmpDir . '/a.txt', 'a');
+
+        (new Process(['git', 'init'], $tmpDir))->mustRun();
+        (new Process(['git', 'config', 'commit.gpgsign', 'false'], $tmpDir))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'PHPUnit'], $tmpDir))->mustRun();
+        (new Process(['git', 'config', 'user.email', 'unit@php.com'], $tmpDir))->mustRun();
+        (new Process(['git', 'branch', '-m', 'main'], $tmpDir))->mustRun();
+        (new Process(['git', 'add', 'a.txt'], $tmpDir))->mustRun();
+        (new Process(['git', 'commit', '-m', 'initial'], $tmpDir))->mustRun();
+
+        $platform = new LocalPlatform();
+        $platform->load($tmpDir, 'main|main');
+
+        static::assertInstanceOf(LocalPullRequest::class, $platform->pullRequest);
+        static::assertSame('empty', $platform->pullRequest->title);
+    }
+}

--- a/tests/Rule/CheckPhpCsFixerTest.php
+++ b/tests/Rule/CheckPhpCsFixerTest.php
@@ -16,13 +16,6 @@ use PHPUnit\Framework\TestCase;
  */
 class CheckPhpCsFixerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (\PHP_VERSION_ID >= 80100) {
-            static::markTestSkipped('cs fixer doesnt work on 8.1 currently');
-        }
-    }
-
     public function testRuleRunsWithoutIssues(): void
     {
         $github = $this->createMock(Github::class);

--- a/tests/Struct/Local/LocalFileTest.php
+++ b/tests/Struct/Local/LocalFileTest.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Tests\Struct\Local;
+
+use Danger\Struct\Local\LocalFile;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \Danger\Struct\Local\LocalFile
+ */
+class LocalFileTest extends TestCase
+{
+    public function testGetContent(): void
+    {
+        $file = new LocalFile(__FILE__);
+        static::assertSame((string) file_get_contents(__FILE__), $file->getContent());
+    }
+}

--- a/tests/Struct/Local/LocalPullRequestTest.php
+++ b/tests/Struct/Local/LocalPullRequestTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace Danger\Tests\Struct\Local;
+
+use Danger\Struct\File;
+use Danger\Struct\Local\LocalPullRequest;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+class LocalPullRequestTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/' . uniqid('local', true);
+
+        mkdir($this->tmpDir);
+        file_put_contents($this->tmpDir . '/a.txt', 'a');
+        file_put_contents($this->tmpDir . '/b.txt', 'b');
+        file_put_contents($this->tmpDir . '/c.txt', 'c');
+
+        (new Process(['git', 'init'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'config', 'commit.gpgsign', 'false'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'config', 'user.name', 'PHPUnit'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'config', 'user.email', 'unit@php.com'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'branch', '-m', 'main'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'add', 'a.txt'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'commit', '-m', 'initial'], $this->tmpDir))->mustRun();
+
+        (new Process(['git', 'checkout', '-b', 'feature'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'add', 'b.txt'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'commit', '-m', 'feature'], $this->tmpDir))->mustRun();
+
+        (new Process(['git', 'checkout', '-b', 'feature2'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'rm', 'a.txt'], $this->tmpDir))->mustRun();
+        file_put_contents($this->tmpDir . '/b.txt', 'b2');
+        (new Process(['git', 'add', 'b.txt', 'c.txt'], $this->tmpDir))->mustRun();
+        (new Process(['git', 'commit', '-m', 'all modes'], $this->tmpDir))->mustRun();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        (new Filesystem())->remove($this->tmpDir);
+    }
+
+    public function testCommits(): void
+    {
+        $pr = new LocalPullRequest($this->tmpDir, 'feature', 'main');
+        static::assertSame('feature', $pr->title);
+
+        $commits = $pr->getCommits();
+
+        static::assertCount(1, $commits);
+
+        $commit = $commits->first();
+        static::assertNotNull($commit);
+
+        static::assertSame('feature', $commit->message);
+        static::assertSame('PHPUnit', $commit->author);
+        static::assertSame('unit@php.com', $commit->authorEmail);
+        static::assertEqualsWithDelta(time(), $commit->createdAt->getTimestamp(), 1);
+    }
+
+    public function testEmptyCommits(): void
+    {
+        $pr = new LocalPullRequest($this->tmpDir, 'main', 'main');
+        static::assertSame('empty', $pr->title);
+
+        static::assertCount(0, $pr->getCommits());
+        static::assertCount(0, $pr->getFiles());
+        static::assertCount(0, $pr->getComments());
+    }
+
+    public function testGetFiles(): void
+    {
+        $pr = new LocalPullRequest($this->tmpDir, 'feature2', 'main');
+
+        $files = $pr->getFiles();
+
+        $files2 = $pr->getFiles();
+
+        static::assertSame($files, $files2);
+
+        $fileA = $files->get('a.txt');
+
+        static::assertNotNull($fileA);
+
+        static::assertSame('a.txt', $fileA->name);
+        static::assertSame(File::STATUS_REMOVED, $fileA->status);
+
+        $fileB = $files->get('b.txt');
+
+        static::assertNotNull($fileB);
+
+        static::assertSame('b2', $fileB->getContent());
+        static::assertSame(File::STATUS_ADDED, $fileB->status);
+
+        $fileC = $files->get('c.txt');
+
+        static::assertNotNull($fileC);
+
+        static::assertSame('c', $fileC->getContent());
+        static::assertSame(File::STATUS_ADDED, $fileC->status);
+    }
+}


### PR DESCRIPTION
Adds `danger local` command to allow running danger locally without an external VCS service

# Todos
- [x] Write tests