### PR TITLE
Allow Github style merge commits in no repeated commits rule

### DIFF
--- a/src/Rule/DisallowRepeatedCommits.php
+++ b/src/Rule/DisallowRepeatedCommits.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Danger\Rule;
 
 use Danger\Context;
+use Danger\Platform\Github\Github;
 
 class DisallowRepeatedCommits
 {
@@ -14,6 +15,13 @@ class DisallowRepeatedCommits
     public function __invoke(Context $context): void
     {
         $messages = $context->platform->pullRequest->getCommits()->getMessages();
+
+        if ($context->platform instanceof Github) {
+            $messages = array_filter(
+                $messages,
+                fn ($message) => !(preg_match('/^Merge branch .* into .*$/', $message) === 1),
+            );
+        }
 
         if (\count($messages) !== \count(array_unique($messages))) {
             $context->failure($this->message);

--- a/tests/Rule/DisallowRepeatedCommitsTest.php
+++ b/tests/Rule/DisallowRepeatedCommitsTest.php
@@ -57,4 +57,52 @@ class DisallowRepeatedCommitsTest extends TestCase
 
         static::assertFalse($context->hasFailures());
     }
+
+    public function testRuleMatchesWithMergeCommits(): void
+    {
+        $commit = new Commit();
+        $commit->message = 'Test';
+
+        $secondCommit = new Commit();
+        $secondCommit->message = 'Test';
+
+        $thirdCommit = new Commit();
+        $thirdCommit->message = 'Merge branch master into feature';
+
+        $github = $this->createMock(Github::class);
+        $pr = $this->createMock(PullRequest::class);
+        $pr->method('getCommits')->willReturn(new CommitCollection([$commit, $secondCommit, $thirdCommit]));
+        $github->pullRequest = $pr;
+
+        $context = new Context($github);
+
+        $rule = new DisallowRepeatedCommits();
+        $rule($context);
+
+        static::assertTrue($context->hasFailures());
+    }
+
+    public function testRuleNotMatchesWithMultipleMergeCommits(): void
+    {
+        $commit = new Commit();
+        $commit->message = 'Test';
+
+        $secondCommit = new Commit();
+        $secondCommit->message = 'Merge branch master into features';
+
+        $thirdCommit = new Commit();
+        $thirdCommit->message = 'Merge branch master into feature';
+
+        $github = $this->createMock(Github::class);
+        $pr = $this->createMock(PullRequest::class);
+        $pr->method('getCommits')->willReturn(new CommitCollection([$commit, $secondCommit, $thirdCommit]));
+        $github->pullRequest = $pr;
+
+        $context = new Context($github);
+
+        $rule = new DisallowRepeatedCommits();
+        $rule($context);
+
+        static::assertFalse($context->hasFailures());
+    }
 }


### PR DESCRIPTION
This adds a filter for Github style merge commits to the repeated commits rule. As it is a feature of the platform which by its automated nature will lead to repeated commit names, it's sensible to filter them out by default (the goal of making the programmer clearly state his intent with every real commit is still achieved).

There are several different approaches one could take to implementing this feature, including adding a dynamic filter based on the current platform or making the filter step configurable. However since i am new to the project and just wanted to get general feedback on the idea i decided on building the most simple version for now. If any of the more complex versions are desired i would also be happy to implement them.