### PR TITLE
Add xml extension to the docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+          extensions: xml
 
       - name: Download box
         run: wget https://github.com/humbug/box/releases/download/4.6.1/box.phar


### PR DESCRIPTION
This PR adds the XML PHP extension to the Docker image.

The XML extension is [enabled by default](https://www.php.net/manual/en/xml.installation.php) in PHP but is not enabled by default in the shivammathur/setup-php@v2 GitHub Action. Including this extension will allow clients who are writing complex configurations for the Danger script parse xml easier.

See also [example configuration](https://github.com/shivammathur/setup-php/blob/main/examples/symfony.yml#L23) for symfony.

Please review the changes and provide feedback. Thank you!