### PR TITLE
fix: retry transient GitHub API failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "symfony/http-client": "^7.2",
         "nyholm/psr7": "^1.8",
         "symfony/finder": "^7.2",
-        "m4tthumphrey/php-gitlab-api": "^12.0"
+        "m4tthumphrey/php-gitlab-api": "^12.0",
+        "php-http/client-common": "^2.7"
     },
     "replace": {
         "symfony/polyfill-ctype": "*",

--- a/src/DependencyInjection/Factory/GithubClientFactory.php
+++ b/src/DependencyInjection/Factory/GithubClientFactory.php
@@ -5,12 +5,29 @@ namespace Danger\DependencyInjection\Factory;
 
 use Github\AuthMethod;
 use Github\Client;
+use Github\HttpClient\Builder;
+use Http\Client\Common\Plugin\RetryPlugin;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestInterface;
 
 class GithubClientFactory
 {
-    public static function build(): Client
+    public static function build(?Builder $httpClientBuilder = null): Client
     {
-        $client = new Client();
+        $builder = $httpClientBuilder ?? new Builder();
+        $builder->addPlugin(new RetryPlugin([
+            'retries' => 3,
+            'exception_decider' => static function (RequestInterface $request, ClientExceptionInterface $exception): bool {
+                // GithubExceptionThrower maps error responses to exceptions carrying the HTTP
+                // status code, so retry only transient failures: network errors and 5xx
+                // responses. Client errors (4xx, e.g. rate limits) bubble up immediately.
+                return $exception instanceof NetworkExceptionInterface
+                    || ($exception->getCode() >= 500 && $exception->getCode() < 600);
+            },
+        ]));
+
+        $client = new Client($builder);
 
         if (isset($_SERVER['GITHUB_TOKEN']) && \is_string($_SERVER['GITHUB_TOKEN'])) {
             $client->authenticate($_SERVER['GITHUB_TOKEN'], null, AuthMethod::ACCESS_TOKEN);

--- a/tests/DependencyInjection/Factory/GithubClientFactoryTest.php
+++ b/tests/DependencyInjection/Factory/GithubClientFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Danger\Tests\DependencyInjection\Factory;
+
+use Danger\DependencyInjection\Factory\GithubClientFactory;
+use Github\Exception\RuntimeException;
+use Github\HttpClient\Builder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @internal
+ */
+#[CoversClass(GithubClientFactory::class)]
+class GithubClientFactoryTest extends TestCase
+{
+    public function testRetriesTransientServerErrors(): void
+    {
+        $mock = new MockHttpClient([
+            new MockResponse('<html><title>Unicorn!</title></html>', ['http_code' => 502]),
+            new MockResponse('{"login": "shyim"}', ['http_code' => 200, 'response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $client = GithubClientFactory::build(new Builder(new Psr18Client($mock)));
+
+        static::assertSame(['login' => 'shyim'], $client->currentUser()->show());
+        static::assertSame(2, $mock->getRequestsCount());
+    }
+
+    public function testDoesNotRetryClientErrors(): void
+    {
+        $mock = new MockHttpClient([
+            new MockResponse('{"message": "Not Found"}', ['http_code' => 404, 'response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $client = GithubClientFactory::build(new Builder(new Psr18Client($mock)));
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            $client->currentUser()->show();
+        } finally {
+            static::assertSame(1, $mock->getRequestsCount());
+        }
+    }
+}


### PR DESCRIPTION
### Problem

When the GitHub API returns a transient error (502/503 "Unicorn!" HTML page, network hiccup), the whole danger run dies with an unhandled exception from `GithubExceptionThrower`:

```
In GithubExceptionThrower.php line 137:
  <!DOCTYPE html>
  ...
  <title>Unicorn! &middot; GitHub</title>
```

Since a danger run makes one API request per rule interaction (files listing, content downloads, comment upsert), a single transient 5xx anywhere fails the whole job as a red check. On shopware/shopware we saw 13 of 75 Danger runs fail in one morning during a degraded-API period, ~85% of them with this exact unicorn page.

### Change

`GithubClientFactory` now registers an `Http\Client\Common\Plugin\RetryPlugin` (already a transitive dependency via `knplabs/github-api`, promoted to a direct require) on the client's HTTP plugin chain:

- 3 retries with the plugin's default exponential backoff (0.5s / 1s / 2s)
- retries only transient failures: network exceptions and responses/exceptions with a 5xx status
- client errors (4xx — not found, validation, rate limits) are **not** retried and bubble up immediately, same as before

A custom `exception_decider` is needed because `GithubExceptionThrower` sits first in the plugin chain (outermost), so error responses reach the retry plugin as `Github\Exception\RuntimeException` (not `HttpException`) — the plugin's default decider would have retried 4xx errors too. The thrower puts the HTTP status into the exception code, which the decider checks.

`build()` gained an optional `Builder` parameter so the behavior is testable with a mock HTTP client; production callers are unaffected.

### Notes

- `GitlabClientFactory` is left as-is; the same treatment could apply if wanted.
- Tests cover both directions: a 502 followed by a 200 succeeds with exactly 2 requests; a 404 fails after exactly 1 request.
